### PR TITLE
Fix root imports that fail when linked

### DIFF
--- a/packages/sdk/src/models/issue.ts
+++ b/packages/sdk/src/models/issue.ts
@@ -1,4 +1,4 @@
-import { gql } from "gql";
+import { gql } from "../gql";
 import { Linear } from "../linear";
 import {
   CreateIssueFromCliMutation,

--- a/packages/sdk/src/models/label.ts
+++ b/packages/sdk/src/models/label.ts
@@ -1,4 +1,4 @@
-import { gql } from "gql";
+import { gql } from "../gql";
 import { Linear } from "../linear";
 import { getIssueIdFromSelection, IssueSelection, updateIssue } from "./issue";
 import {

--- a/packages/sdk/src/models/team.ts
+++ b/packages/sdk/src/models/team.ts
@@ -1,4 +1,4 @@
-import { gql } from "gql";
+import { gql } from "../gql";
 import { Linear } from "../linear";
 import {
   GetTeamNamesFromCliQuery,


### PR DESCRIPTION
Originally I was using TypeScript's baseDir importing feature, but that doesn't work too well with lerna bootstrap so I'm scrapping that for less magical paths. 